### PR TITLE
Fix style of icons and headings, fix bash script syntax.

### DIFF
--- a/site/.vitepress/theme/components/index/Index.vue
+++ b/site/.vitepress/theme/components/index/Index.vue
@@ -363,6 +363,7 @@ import Feature from './Feature.vue';
 
 .wren-home-feature-title img {
   width: 24px;
+  margin: 0;
 }
 
 .wren-home-feature-title h3 {
@@ -389,6 +390,7 @@ import Feature from './Feature.vue';
 
   > img {
     filter: none;
+    margin: 0;
   }
 }
 

--- a/site/guide/wrenidm-sync.md
+++ b/site/guide/wrenidm-sync.md
@@ -26,15 +26,14 @@ docker compose up -d
 curl -k \
   -u openidm-admin:openidm-admin \
   -XPOST \
-  "https://localhost:8443/openidm/recon?        
-_action=recon&mapping=csvEmployee_managedUser"
+  "https://localhost:8443/openidm/recon?_action=recon&mapping=csvEmployee_managedUser"
 ```
 1. In the Wren:IDM admin user interface, refresh the user management page to confirm the existence of new managed user identities under 'Manage' → 'User'
 2. In our case Wren:IDM is configured to automatically propagate changes to LDAP. Ensure the synchronization by listing existing LDAP accounts using this command:
 ```bash
-docker exec ldap ldapsearch -H ldap://localhost -x -D             
-"cn=admin,dc=wrensecurity,dc=org" -w admin -b 
-"dc=wrensecurity,dc=org" "(objectClass=inetOrgPerson)"
+docker exec ldap ldapsearch -H ldap://localhost -x -D \
+  "cn=admin,dc=wrensecurity,dc=org" -w admin -b \
+  "dc=wrensecurity,dc=org" "(objectClass=inetOrgPerson)"
 ```
 1. When you’re done, feel free to continue exploring or remove the Docker containers using:
 ```bash


### PR DESCRIPTION
After upgrade to a new major vitepress version there occured a bug with misalignment of icons + headings. It was caused by an added margin of images.

I also fixed syntax of bash scripts in guide: Identity Synchronization With Wren:IDM